### PR TITLE
CollectionExt: add Array update, move and moved

### DIFF
--- a/Sources/RudifaUtilPkg/CollectionExt.swift
+++ b/Sources/RudifaUtilPkg/CollectionExt.swift
@@ -11,12 +11,20 @@ import Foundation
 public extension Array where Element: Equatable {
     /// Return array containing elements of self that are also in other, plus elements from other that are not in self
     /// - Parameter other: the array to update from
+    /// - Returns: updated array
     func updatedPreservingOrder(from other: Array) -> [Element] {
         var updated: [Element] = filter { other.contains($0) }
         updated += other.filter { !self.contains($0) }
         return updated
     }
+    /// Update array in-place to contain elements of self that are also in other, plus elements from other that are not in self
+    /// - Parameter other: the array to update from
+    mutating func updatePreservingOrder(from other: Array) {
+        self = updatedPreservingOrder(from: other)
+    }
+}
 
+public extension Array {
     /// Return array containing elements of self that are also in other, plus elements from other that are not in self
     /// - Parameters:
     ///   - other: the array to update from
@@ -26,5 +34,65 @@ public extension Array where Element: Equatable {
         var updated: [Element] = filter { elt1 in other.contains { (elt2) -> Bool in predicate(elt1, elt2) } }
         updated += other.filter { elt1 in !self.contains { (elt2) -> Bool in predicate(elt1, elt2) } }
         return updated
+    }
+
+    /// Update array in-place to contain elements of self that are also in other, plus elements from other that are not in self
+    /// - Parameters:
+    ///   - other: the array to update from
+    ///   - predicate: returns true if a pair of elements, one from each array, satisfies it
+    mutating func updatePreservingOrder(from other: Array, predicate: (Element, Element) -> Bool) {
+        self = updatedPreservingOrder(from: other, predicate: predicate)
+    }
+}
+
+public extension Array where Element: Equatable {
+    /// Move the element to index, modifying self in-place
+    /// - Parameters:
+    ///   - element: to be moved
+    ///   - index: new position of the element
+    mutating func move(element: Element, to index: Index) {
+        if let oldIndex = firstIndex(of: element) {
+            if index >= 0, index < count {
+                let element = remove(at: oldIndex)
+                insert(element, at: index)
+            }
+        }
+    }
+
+    /// Move the element matching the predicate to index
+    /// - Parameters:
+    ///   - element: to be moved
+    ///   - index: new position of the element
+    /// - Returns: modified copy of self
+    func moved(element: Element, to index: Index) -> [Element] {
+        var temp = self
+        temp.move(element: element, to: index)
+        return temp
+    }
+}
+
+public extension Array {
+    /// Move the element matching the predicate to index, modifying self in-place
+    /// - Parameters:
+    ///   - predicate: allows the move if true
+    ///   - index: new position of the element
+    mutating func move(where predicate: (Element) -> Bool, to index: Index) {
+        if let oldIndex = firstIndex(where: predicate) {
+            if index >= 0, index < count {
+                let element = remove(at: oldIndex)
+                insert(element, at: index)
+            }
+        }
+    }
+
+    /// Move the element matching the predicate to index
+    /// - Parameters:
+    ///   - predicate: allows the move if true
+    ///   - index: new position of the element
+    /// - Returns: modified copy of self
+    func moved(where predicate: (Element) -> Bool, to index: Index) -> [Element] {
+        var temp = self
+        temp.move(where: predicate, to: index)
+        return temp
     }
 }

--- a/Tests/RudifaUtilPkgTests/CollectionExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/CollectionExtTests.swift
@@ -8,8 +8,9 @@
 
 import XCTest
 
-// a sample struct for testing the Array extension methods
-struct CalendarData: Codable, Equatable {
+// MARK: sample structs for testing the Array extension methods
+
+struct MockCalendarData: Codable, Equatable {
     let title: String
     var hidden: Bool = false
 
@@ -23,7 +24,7 @@ struct CalendarData: Codable, Equatable {
     ///   - lhs: first comparand
     ///   - rhs: second comparand
     /// - Returns: true if comparands are strictly equal
-    static func == (lhs: CalendarData, rhs: CalendarData) -> Bool {
+    static func == (lhs: MockCalendarData, rhs: MockCalendarData) -> Bool {
         return lhs.title == rhs.title && lhs.hidden == rhs.hidden
     }
 
@@ -31,9 +32,16 @@ struct CalendarData: Codable, Equatable {
     /// - Parameters:
     ///   - lhs: first comparand
     ///   - rhs: second comparand
-    /// - Returns: true if comparands have the same tutle
-    static func sameTitle(lhs: CalendarData, rhs: CalendarData) -> Bool {
+    /// - Returns: true if comparands have the same title
+    static func sameTitle(lhs: MockCalendarData, rhs: MockCalendarData) -> Bool {
         return lhs.title == rhs.title
+    }
+
+    /// Partial equality comparison
+    /// - Parameter other: the instance to compare to
+    /// - Returns: true if other has the same title
+    func sameTitle(as other: MockCalendarData) -> Bool {
+        return title == other.title
     }
 }
 
@@ -46,28 +54,46 @@ class CollectionUtilTests: XCTestCase {
     override func setUp() {}
     override func tearDown() {}
 
-    func test_updatedPreservingOrder_1() {
-        // test func updatedPreservingOrder(from other: Array) -> [Element] on [Int]
+    func test_updatedPreservingOrder_1A() {
+        // func updatedPreservingOrder(from other: Array) -> [Element]
+        // returns an updated array
 
-        let aaa = [5, 4, 3, 2, 1]
+        let array = [5, 4, 3, 2, 1]
 
-        XCTAssertEqual(aaa.updatedPreservingOrder(from: aaa), [5, 4, 3, 2, 1])
-        XCTAssertEqual(aaa.updatedPreservingOrder(from: [1, 2, 3, 4, 5]), [5, 4, 3, 2, 1])
-        XCTAssertEqual(aaa.updatedPreservingOrder(from: [1, 2, 3, 4, 5, 6, 7]), [5, 4, 3, 2, 1, 6, 7])
-        XCTAssertEqual(aaa.updatedPreservingOrder(from: [3, 4, 5, 6, 7]), [5, 4, 3, 6, 7])
-        XCTAssertEqual(aaa.updatedPreservingOrder(from: [6, 7]), [6, 7])
+        XCTAssertEqual(array.updatedPreservingOrder(from: array), [5, 4, 3, 2, 1])
+        XCTAssertEqual(array.updatedPreservingOrder(from: [1, 2, 3, 4, 5]), [5, 4, 3, 2, 1])
+        XCTAssertEqual(array.updatedPreservingOrder(from: [1, 2, 3, 4, 5, 6, 7]), [5, 4, 3, 2, 1, 6, 7])
+        XCTAssertEqual(array.updatedPreservingOrder(from: [3, 4, 5, 6, 7]), [5, 4, 3, 6, 7])
+        XCTAssertEqual(array.updatedPreservingOrder(from: [6, 7, 3]), [3, 6, 7])
+    }
+
+    func test_updatedPreservingOrder_1B() {
+        // mutating func updatePreservingOrder(from other: Array)
+        // updates array in-place
+
+        var array = [5, 4, 3, 2, 1]
+
+        array.updatePreservingOrder(from: array); XCTAssertEqual(array, [5, 4, 3, 2, 1])
+        array.updatePreservingOrder(from: [1, 2, 3, 4, 5]); XCTAssertEqual(array, [5, 4, 3, 2, 1])
+        array.updatePreservingOrder(from: [1, 2, 3, 4, 5, 6, 7]); XCTAssertEqual(array, [5, 4, 3, 2, 1, 6, 7])
+        array.updatePreservingOrder(from: [3, 4, 5, 6, 7]); XCTAssertEqual(array, [5, 4, 3, 6, 7])
+        array.updatePreservingOrder(from: [6, 7, 3]); XCTAssertEqual(array, [3, 6, 7])
     }
 
     func test_updatePreservingOrder_2() {
-        // test func updatedPreservingOrder(from other: Array) -> [Element] on [CalendarData]
+        // func updatedPreservingOrder(from other: Array) -> [Element]
+        // returns an updated array
+
+        // mutating func updatePreservingOrder(from other: Array)
+        // updates array in-place
 
         struct MockCalendar {
             let title: String
             let otherData = Date()
         }
 
-        var calendarDataArray = [CalendarData(title: "Newbie", hidden: false),
-                                 CalendarData(title: "Oldie", hidden: true)]
+        var calendarDataArray = [MockCalendarData(title: "Newbie", hidden: false),
+                                 MockCalendarData(title: "Oldie", hidden: true)]
 
         printClassAndFunc(info: "original calendarDataArray= \(calendarDataArray.map { $0.string })")
 
@@ -75,19 +101,30 @@ class CollectionUtilTests: XCTestCase {
                                  MockCalendar(title: "Oldie"),
                                  MockCalendar(title: "Pretty")]
 
-        // emulate the operation in SharedUserDefaults.updateCalendarsAndSelection
-        calendarDataArray = calendarDataArray.updatedPreservingOrder(from: incomingCalendars.map { CalendarData(title: $0.title) })
+        let incomingCalendarDataArray = incomingCalendars.map { MockCalendarData(title: $0.title) }
+
+        let expectedResultStringArray = ["Newbie visible", "Oldie visible", "Pretty visible"]
+
+        let updatedCalendarDataArray = calendarDataArray.updatedPreservingOrder(from: incomingCalendarDataArray)
 
         printClassAndFunc(info: "updated calendarDataArray= \(calendarDataArray.map { $0.string })")
+        XCTAssertEqual(updatedCalendarDataArray.map { $0.string }, expectedResultStringArray)
+
+        calendarDataArray.updatePreservingOrder(from: incomingCalendarDataArray)
+        XCTAssertEqual(calendarDataArray.map { $0.string }, expectedResultStringArray)
     }
 
     func test_updatePreservingOrder_3() {
-        // test func updatedPreservingOrder(from other: Array, predicate: (Element, Element) -> Bool) -> [Element] on CalendarData
+        // func updatedPreservingOrder(from other: Array, predicate: (Element, Element) -> Bool) -> [Element]
+        // returns an updated array
 
-        let calendarDataArray = [CalendarData(title: "Alice", hidden: false),
-                                 CalendarData(title: "Bobby", hidden: true),
-                                 CalendarData(title: "Charlie", hidden: false),
-                                 CalendarData(title: "Debbie", hidden: true)]
+        // mutating func updatePreservingOrder(from other: Array, predicate: (Element, Element) -> Bool)
+        // updates array in-place
+
+        let calendarDataArray = [MockCalendarData(title: "Alice", hidden: false),
+                                 MockCalendarData(title: "Bobby", hidden: true),
+                                 MockCalendarData(title: "Charlie", hidden: false),
+                                 MockCalendarData(title: "Debbie", hidden: true)]
 
         let incomingCalendars = [MockCalendar(title: "Newbie"),
                                  MockCalendar(title: "Oldie"),
@@ -95,7 +132,7 @@ class CollectionUtilTests: XCTestCase {
                                  MockCalendar(title: "Charlie"),
                                  MockCalendar(title: "Bobby")]
 
-        let incomingCalendarDataArray = incomingCalendars.map { CalendarData(title: $0.title) }
+        let incomingCalendarDataArray = incomingCalendars.map { MockCalendarData(title: $0.title) }
 
         let expectedResultStringArray = ["Bobby hidden", "Charlie visible", "Newbie visible", "Oldie visible", "Pretty visible"]
 
@@ -105,34 +142,138 @@ class CollectionUtilTests: XCTestCase {
             ///   - elt1: element from the first array
             ///   - elt2: element from the other array
             /// - Returns: boolean result
-            func sameTitle(elt1: CalendarData, elt2: CalendarData) -> Bool {
+            func sameTitle(elt1: MockCalendarData, elt2: MockCalendarData) -> Bool {
                 return elt1.title == elt2.title
             }
 
             // using the supplied predicate
+
             let updatedCalendarDataArray = calendarDataArray.updatedPreservingOrder(from: incomingCalendarDataArray,
                                                                                     predicate: sameTitle)
 
             printClassAndFunc(info: "updatedCalendarDataArray= \(updatedCalendarDataArray.map { $0.string })")
             XCTAssertEqual(updatedCalendarDataArray.map { $0.string }, expectedResultStringArray)
+
+            var localCopy = calendarDataArray
+            localCopy.updatePreservingOrder(from: incomingCalendarDataArray,
+                                            predicate: sameTitle)
+            XCTAssertEqual(localCopy.map { $0.string }, expectedResultStringArray)
         }
 
         do {
             // using the inline predicate
+
             let updatedCalendarDataArray = calendarDataArray.updatedPreservingOrder(from: incomingCalendarDataArray,
                                                                                     predicate: { (elt1, elt2) -> Bool in elt1.title == elt2.title })
 
             printClassAndFunc(info: "updatedCalendarDataArray= \(updatedCalendarDataArray.map { $0.string })")
             XCTAssertEqual(updatedCalendarDataArray.map { $0.string }, expectedResultStringArray)
+
+            var localCopy = calendarDataArray
+            localCopy.updatePreservingOrder(from: incomingCalendarDataArray,
+                                            predicate: { (elt1, elt2) -> Bool in elt1.title == elt2.title })
+            XCTAssertEqual(localCopy.map { $0.string }, expectedResultStringArray)
         }
 
         do {
             // using the predicate provided by the class
+
             let updatedCalendarDataArray = calendarDataArray.updatedPreservingOrder(from: incomingCalendarDataArray,
-                                                                                    predicate: CalendarData.sameTitle)
+                                                                                    predicate: MockCalendarData.sameTitle)
 
             printClassAndFunc(info: "updatedCalendarDataArray= \(updatedCalendarDataArray.map { $0.string })")
             XCTAssertEqual(updatedCalendarDataArray.map { $0.string }, expectedResultStringArray)
+
+            var localCopy = calendarDataArray
+            localCopy.updatePreservingOrder(from: incomingCalendarDataArray,
+                                            predicate: MockCalendarData.sameTitle)
+            XCTAssertEqual(localCopy.map { $0.string }, expectedResultStringArray)
         }
+    }
+
+    func test_move() {
+        // mutating func move(element: Element, to index: Index)
+        // moves the element updating the array in-place
+
+        var array = ["A", "B", "C", "D"]
+
+        array.move(element: "D", to: 0); XCTAssertEqual(array, ["D", "A", "B", "C"])
+        array.move(element: "D", to: 1); XCTAssertEqual(array, ["A", "D", "B", "C"])
+        array.move(element: "D", to: 2); XCTAssertEqual(array, ["A", "B", "D", "C"])
+        array.move(element: "D", to: 3); XCTAssertEqual(array, ["A", "B", "C", "D"])
+        array.move(element: "D", to: 4); XCTAssertEqual(array, ["A", "B", "C", "D"])
+
+        array.move(element: "A", to: 0); XCTAssertEqual(array, ["A", "B", "C", "D"])
+        array.move(element: "A", to: 1); XCTAssertEqual(array, ["B", "A", "C", "D"])
+        array.move(element: "A", to: 2); XCTAssertEqual(array, ["B", "C", "A", "D"])
+        array.move(element: "A", to: 3); XCTAssertEqual(array, ["B", "C", "D", "A"])
+        array.move(element: "A", to: 4); XCTAssertEqual(array, ["B", "C", "D", "A"])
+
+        array.move(element: "Q", to: 3); XCTAssertEqual(array, ["B", "C", "D", "A"])
+    }
+
+    func test_moved() {
+        // func moved(element: Element, to index: Index) -> [Element]
+        // returns a copy of array, with the element moved
+
+        let array = ["A", "B", "C", "D"]
+
+        XCTAssertEqual(array.moved(element: "D", to: 0), ["D", "A", "B", "C"])
+        XCTAssertEqual(array.moved(element: "D", to: 1), ["A", "D", "B", "C"])
+        XCTAssertEqual(array.moved(element: "D", to: 2), ["A", "B", "D", "C"])
+        XCTAssertEqual(array.moved(element: "D", to: 3), ["A", "B", "C", "D"])
+        XCTAssertEqual(array.moved(element: "D", to: 4), ["A", "B", "C", "D"])
+
+        XCTAssertEqual(array.moved(element: "A", to: 0), ["A", "B", "C", "D"])
+        XCTAssertEqual(array.moved(element: "A", to: 1), ["B", "A", "C", "D"])
+        XCTAssertEqual(array.moved(element: "A", to: 2), ["B", "C", "A", "D"])
+        XCTAssertEqual(array.moved(element: "A", to: 3), ["B", "C", "D", "A"])
+        XCTAssertEqual(array.moved(element: "A", to: 4), ["A", "B", "C", "D"])
+
+        XCTAssertEqual(array.moved(element: "Q", to: 4), ["A", "B", "C", "D"])
+    }
+
+    func test_move_where() {
+        // mutating func move(where predicate: (Element) -> Bool, to index: Index)
+        // moves the element matching the predicate, updating the array in-place
+
+        var array = [MockCalendarData(title: "Anemone", hidden: false),
+                     MockCalendarData(title: "Begonia", hidden: true),
+                     MockCalendarData(title: "Clematis", hidden: false),
+                     MockCalendarData(title: "Dahlia", hidden: true)]
+
+        array.move(where: MockCalendarData(title: "Dahlia").sameTitle, to: 0); XCTAssertEqual(array.map { $0.title }, ["Dahlia", "Anemone", "Begonia", "Clematis"])
+        array.move(where: MockCalendarData(title: "Dahlia").sameTitle, to: 1); XCTAssertEqual(array.map { $0.title }, ["Anemone", "Dahlia", "Begonia", "Clematis"])
+        array.move(where: MockCalendarData(title: "Dahlia").sameTitle, to: 2); XCTAssertEqual(array.map { $0.title }, ["Anemone", "Begonia", "Dahlia", "Clematis"])
+        array.move(where: MockCalendarData(title: "Dahlia").sameTitle, to: 3); XCTAssertEqual(array.map { $0.title }, ["Anemone", "Begonia", "Clematis", "Dahlia"])
+
+        array.move(where: MockCalendarData(title: "Anemone").sameTitle, to: 0); XCTAssertEqual(array.map { $0.title }, ["Anemone", "Begonia", "Clematis", "Dahlia"])
+        array.move(where: MockCalendarData(title: "Anemone").sameTitle, to: 1); XCTAssertEqual(array.map { $0.title }, ["Begonia", "Anemone", "Clematis", "Dahlia"])
+        array.move(where: MockCalendarData(title: "Anemone").sameTitle, to: 2); XCTAssertEqual(array.map { $0.title }, ["Begonia", "Clematis", "Anemone", "Dahlia"])
+        array.move(where: MockCalendarData(title: "Anemone").sameTitle, to: 3); XCTAssertEqual(array.map { $0.title }, ["Begonia", "Clematis", "Dahlia", "Anemone"])
+
+        array.move(where: MockCalendarData(title: "Orchid").sameTitle, to: 0); XCTAssertEqual(array.map { $0.title }, ["Begonia", "Clematis", "Dahlia", "Anemone"])
+    }
+
+    func test_moved_where() {
+        // func moved(where predicate: (Element) -> Bool, to index: Index) -> [Element]
+        // returns a copy of array, with the element that matched pthe predicate moved
+
+        let array = [MockCalendarData(title: "Anemone", hidden: false),
+                     MockCalendarData(title: "Begonia", hidden: true),
+                     MockCalendarData(title: "Clematis", hidden: false),
+                     MockCalendarData(title: "Dahlia", hidden: true)]
+
+        XCTAssertEqual(array.moved(where: MockCalendarData(title: "Dahlia").sameTitle, to: 0).map { $0.title }, ["Dahlia", "Anemone", "Begonia", "Clematis"])
+        XCTAssertEqual(array.moved(where: MockCalendarData(title: "Dahlia").sameTitle, to: 1).map { $0.title }, ["Anemone", "Dahlia", "Begonia", "Clematis"])
+        XCTAssertEqual(array.moved(where: MockCalendarData(title: "Dahlia").sameTitle, to: 2).map { $0.title }, ["Anemone", "Begonia", "Dahlia", "Clematis"])
+        XCTAssertEqual(array.moved(where: MockCalendarData(title: "Dahlia").sameTitle, to: 3).map { $0.title }, ["Anemone", "Begonia", "Clematis", "Dahlia"])
+
+        XCTAssertEqual(array.moved(where: MockCalendarData(title: "Anemone").sameTitle, to: 0).map { $0.title }, ["Anemone", "Begonia", "Clematis", "Dahlia"])
+        XCTAssertEqual(array.moved(where: MockCalendarData(title: "Anemone").sameTitle, to: 1).map { $0.title }, ["Begonia", "Anemone", "Clematis", "Dahlia"])
+        XCTAssertEqual(array.moved(where: MockCalendarData(title: "Anemone").sameTitle, to: 2).map { $0.title }, ["Begonia", "Clematis", "Anemone", "Dahlia"])
+        XCTAssertEqual(array.moved(where: MockCalendarData(title: "Anemone").sameTitle, to: 3).map { $0.title }, ["Begonia", "Clematis", "Dahlia", "Anemone"])
+
+        XCTAssertEqual(array.moved(where: MockCalendarData(title: "Orchid").sameTitle, to: 3).map { $0.title }, ["Anemone", "Begonia", "Clematis", "Dahlia"])
     }
 }


### PR DESCRIPTION
- add Array update, move and moved
- expand CollectionExtTests

add mutating func updatePreservingOrder(from other: Array)
add mutating func updatePreservingOrder(from other: Array, predicate: (Element, Element) -> Bool)
add mutating func move(element: Element, to index: Index)
add func moved(element: Element, to index: Index) -> [Element]
add mutating func move(where predicate: (Element) -> Bool, to index: Index)
add func moved(where predicate: (Element) -> Bool, to index: Index) -> [Element]