### PR TITLE
CollectionExt: add Array move and moved variants

### DIFF
--- a/Sources/RudifaUtilPkg/CollectionExt.swift
+++ b/Sources/RudifaUtilPkg/CollectionExt.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionExt.swift v.0.2.0
+//  CollectionExt.swift v.0.6.0
 //  RudifaUtilPkg
 //
 //  Created by Rudolf Farkas on 24.12.19.
@@ -17,6 +17,7 @@ public extension Array where Element: Equatable {
         updated += other.filter { !self.contains($0) }
         return updated
     }
+
     /// Update array in-place to contain elements of self that are also in other, plus elements from other that are not in self
     /// - Parameter other: the array to update from
     mutating func updatePreservingOrder(from other: Array) {
@@ -72,6 +73,27 @@ public extension Array where Element: Equatable {
 }
 
 public extension Array {
+    /// Move the element at old index to new index, modifying self in-place
+    /// - Parameters:
+    ///   - old: index of the element to move
+    ///   - new: new index of the element
+    mutating func move(atIndex old: Index, toIndex new: Index) {
+        if old != new, indices.contains(old), indices.contains(new) {
+            insert(remove(at: old), at: new)
+        }
+    }
+
+    /// Move the element at old index to new index
+    /// - Parameters:
+    ///   - old: index of the element to move
+    ///   - new: new index of the element
+    /// - Returns: modified copy of self
+    func moved(atIndex old: Index, toIndex new: Index) -> [Element] {
+        var temp = self
+        temp.move(atIndex: old, toIndex: new)
+        return temp
+    }
+
     /// Move the element matching the predicate to index, modifying self in-place
     /// - Parameters:
     ///   - predicate: allows the move if true

--- a/Tests/RudifaUtilPkgTests/CollectionExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/CollectionExtTests.swift
@@ -1,5 +1,5 @@
 //
-//  CollectionUtilTests.swift v.0.2.0
+//  CollectionExtTests.swift v.0.6.0
 //  RudifaUtilPkg
 //
 //  Created by Rudolf Farkas on 24.12.19.
@@ -50,7 +50,7 @@ struct MockCalendar {
     let otherData = Date()
 }
 
-class CollectionUtilTests: XCTestCase {
+class CollectionExtTests: XCTestCase {
     override func setUp() {}
     override func tearDown() {}
 
@@ -191,7 +191,28 @@ class CollectionUtilTests: XCTestCase {
         }
     }
 
-    func test_move() {
+    func test_move_element_atIndex_to_index() {
+        // mutating func move(atIndex old: Index, toIndex new: Index)
+        // moves the element updating the array in-place
+
+        var array = ["A", "B", "C", "D"]
+
+        array.move(atIndex: 3, toIndex: 0); XCTAssertEqual(array, ["D", "A", "B", "C"])
+        array.move(atIndex: 0, toIndex: 1); XCTAssertEqual(array, ["A", "D", "B", "C"])
+        array.move(atIndex: 1, toIndex: 2); XCTAssertEqual(array, ["A", "B", "D", "C"])
+        array.move(atIndex: 2, toIndex: 3); XCTAssertEqual(array, ["A", "B", "C", "D"])
+        array.move(atIndex: 3, toIndex: 4); XCTAssertEqual(array, ["A", "B", "C", "D"])
+
+        array.move(atIndex: 0, toIndex: 0); XCTAssertEqual(array, ["A", "B", "C", "D"])
+        array.move(atIndex: 0, toIndex: 1); XCTAssertEqual(array, ["B", "A", "C", "D"])
+        array.move(atIndex: 1, toIndex: 2); XCTAssertEqual(array, ["B", "C", "A", "D"])
+        array.move(atIndex: 2, toIndex: 3); XCTAssertEqual(array, ["B", "C", "D", "A"])
+        array.move(atIndex: 3, toIndex: 4); XCTAssertEqual(array, ["B", "C", "D", "A"])
+
+        array.move(atIndex: 42, toIndex: 3); XCTAssertEqual(array, ["B", "C", "D", "A"])
+    }
+
+    func test_move_element_to_index() {
         // mutating func move(element: Element, to index: Index)
         // moves the element updating the array in-place
 
@@ -212,7 +233,28 @@ class CollectionUtilTests: XCTestCase {
         array.move(element: "Q", to: 3); XCTAssertEqual(array, ["B", "C", "D", "A"])
     }
 
-    func test_moved() {
+    func test_moved_element_at_to_index() {
+        // func moved(atIndex old: Index, toIndex new: Index) -> [Element]
+        // returns a copy of array, with the element moved
+
+        let array = ["A", "B", "C", "D"]
+
+        XCTAssertEqual(array.moved(atIndex: 3, toIndex: 0), ["D", "A", "B", "C"])
+        XCTAssertEqual(array.moved(atIndex: 3, toIndex: 1), ["A", "D", "B", "C"])
+        XCTAssertEqual(array.moved(atIndex: 3, toIndex: 2), ["A", "B", "D", "C"])
+        XCTAssertEqual(array.moved(atIndex: 3, toIndex: 3), ["A", "B", "C", "D"])
+        XCTAssertEqual(array.moved(atIndex: 3, toIndex: 4), ["A", "B", "C", "D"])
+
+        XCTAssertEqual(array.moved(atIndex: 0, toIndex: 0), ["A", "B", "C", "D"])
+        XCTAssertEqual(array.moved(atIndex: 0, toIndex: 1), ["B", "A", "C", "D"])
+        XCTAssertEqual(array.moved(atIndex: 0, toIndex: 2), ["B", "C", "A", "D"])
+        XCTAssertEqual(array.moved(atIndex: 0, toIndex: 3), ["B", "C", "D", "A"])
+        XCTAssertEqual(array.moved(atIndex: 0, toIndex: 4), ["A", "B", "C", "D"])
+
+        XCTAssertEqual(array.moved(atIndex: 42, toIndex: 4), ["A", "B", "C", "D"])
+    }
+
+    func test_moved_element_to_index() {
         // func moved(element: Element, to index: Index) -> [Element]
         // returns a copy of array, with the element moved
 


### PR DESCRIPTION
CollectionExt: add Array move and moved variants; expand CollectionExtTests

- add mutating func move(atIndex old: Index, toIndex new: Index)
- add func moved(atIndex old: Index, toIndex new: Index) -> [Element]
- add unit tests