### PR TITLE
extension CaseIterable where Self: Equatable: add func next(next:); d…

### DIFF
--- a/Sources/RudifaUtilPkg/EnumExt.swift
+++ b/Sources/RudifaUtilPkg/EnumExt.swift
@@ -14,10 +14,15 @@ import Foundation
  ```
     enum MyEnum: CaseIterable { case a, b, c }
     var letter = MyEnum.a
-    letter = letter.next
+    letter.next()  // .b
+    letter.next()  // .c
+    letter.next()  // .a
+    letter.next()  // .b
+    letter.next(false)  // .a
+    letter.next(false)  // .c
  ```
  */
-extension CaseIterable where Self: Equatable {
+public extension CaseIterable where Self: Equatable {
     /// Returns allCases as Array
     private var all: [Self] {
         return Array(Self.allCases)
@@ -34,22 +39,29 @@ extension CaseIterable where Self: Equatable {
     }
 
     /// Returns the next enumerated value (circular)
-    public var next: Self {
+    var next: Self {
         return all[(index + 1) % count]
     }
 
     /// Returns the previous enumerated value (circular)
-    public var prev: Self {
+    var prev: Self {
         return all[(index + count - 1) % count]
     }
 
-    /// Perform circular increment or decrement of self
-    public mutating func increment(next: Bool) {
+    /// Increments or decrements self (circular)
+    mutating func next(_ next: Bool = true) {
         self = next ? self.next : prev
     }
 
-    /// Perform circular increment or decrement of self and return it
-    public mutating func incremented(next: Bool) -> Self {
+    /// Increments or decrements self (circular)
+    @available(*, deprecated, message: "use .next(next:) instead")
+    mutating func increment(next: Bool) {
+        self = next ? self.next : prev
+    }
+
+    /// Returns an incremented or decremented copy of self (circular)
+    @available(*, deprecated, message: "use properties .next or .prev instead")
+    mutating func incremented(next: Bool) -> Self {
         increment(next: next)
         return self
     }

--- a/Tests/RudifaUtilPkgTests/EnumExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/EnumExtTests.swift
@@ -17,68 +17,90 @@ class EnumExtTests: XCTestCase {
         case north, east, south, west
     }
 
-    func test_enum_next() {
-        var side = Windrose.north
-        XCTAssertEqual(side, .north)
-        side = side.next
-        XCTAssertEqual(side, .east)
-        side = side.next
-        XCTAssertEqual(side, .south)
-        side = side.next
-        XCTAssertEqual(side, .west)
-        side = side.next
-        XCTAssertEqual(side, .north)
-        side = side.next
-        XCTAssertEqual(side, .east)
+    func test_func_next() {
+        // func next() modifies the value forwards (or backwards)
+        enum MyEnum: CaseIterable { case a, b, c }
+        var letter = MyEnum.a; XCTAssertEqual(letter, .a)
+        letter.next(); XCTAssertEqual(letter, .b)
+        letter.next(); XCTAssertEqual(letter, .c)
+        letter.next(); XCTAssertEqual(letter, .a)
+        letter.next(); XCTAssertEqual(letter, .b)
+        letter.next(false); XCTAssertEqual(letter, .a)
+        letter.next(false); XCTAssertEqual(letter, .c)
+        letter.next(false); XCTAssertEqual(letter, .b)
+        letter.next(false); XCTAssertEqual(letter, .a)
     }
 
-    func test_enum_prev() {
-        var side = Windrose.north
-        XCTAssertEqual(side, .north)
-        side = side.prev
-        XCTAssertEqual(side, .west)
-        side = side.prev
-        XCTAssertEqual(side, .south)
-        side = side.prev
-        XCTAssertEqual(side, .east)
-        side = side.prev
-        XCTAssertEqual(side, .north)
-        side = side.prev
-        XCTAssertEqual(side, .west)
+    func test_func_next_2() {
+        // func next() modifies the value forwards (or backwards)
+        var side = Windrose.north; XCTAssertEqual(side, .north)
+        side.next(); XCTAssertEqual(side, .east)
+        side.next(true); XCTAssertEqual(side, .south)
+        side.next(); XCTAssertEqual(side, .west)
+        side.next(); XCTAssertEqual(side, .north)
+        side.next(); XCTAssertEqual(side, .east)
+
+        side.next(false); XCTAssertEqual(side, .north)
+        side.next(false); XCTAssertEqual(side, .west)
+        side.next(false); XCTAssertEqual(side, .south)
+        side.next(false); XCTAssertEqual(side, .east)
+        side.next(false); XCTAssertEqual(side, .north)
+    }
+
+    func test_property_next() {
+        // property next returns the next value (circular)
+        var side = Windrose.north; XCTAssertEqual(side, .north)
+        side = side.next; XCTAssertEqual(side, .east)
+        side = side.next; XCTAssertEqual(side, .south)
+        side = side.next; XCTAssertEqual(side, .west)
+        side = side.next; XCTAssertEqual(side, .north)
+        side = side.next; XCTAssertEqual(side, .east)
+    }
+
+    func test_property_prev() {
+        // property prev returns the previous value (circular)
+        var side = Windrose.north; XCTAssertEqual(side, .north)
+        side = side.prev; XCTAssertEqual(side, .west)
+        side = side.prev; XCTAssertEqual(side, .south)
+        side = side.prev; XCTAssertEqual(side, .east)
+        side = side.prev; XCTAssertEqual(side, .north)
+        side = side.prev; XCTAssertEqual(side, .west)
+    }
+
+    func test_enum_one_case() {
+        enum MyEnum0 {} // no cases - cannot create a variable
+
+        enum MyEnum1: CaseIterable, Equatable {
+            case oneAndOnly
+        }
+
+        var val = MyEnum1.oneAndOnly; XCTAssertEqual(val, .oneAndOnly)
+        val.next(); XCTAssertEqual(val, .oneAndOnly)
+        val.next(false); XCTAssertEqual(val, .oneAndOnly)
+
+        XCTAssertEqual(val.next, .oneAndOnly)
+        XCTAssertEqual(val.prev, .oneAndOnly)
     }
 
     func test_enum_increment() {
         var side = Windrose.north
         XCTAssertEqual(side, .north)
-        side.increment(next: true)
-        XCTAssertEqual(side, .east)
-        side.increment(next: true)
-        XCTAssertEqual(side, .south)
-        side.increment(next: true)
-        XCTAssertEqual(side, .west)
-        side.increment(next: true)
-        XCTAssertEqual(side, .north)
-        side.increment(next: true)
-        XCTAssertEqual(side, .east)
+        side.increment(next: true); XCTAssertEqual(side, .east)
+        side.increment(next: true); XCTAssertEqual(side, .south)
+        side.increment(next: true); XCTAssertEqual(side, .west)
+        side.increment(next: true); XCTAssertEqual(side, .north)
+        side.increment(next: true); XCTAssertEqual(side, .east)
 
-        side.increment(next: false)
-        XCTAssertEqual(side, .north)
-        side.increment(next: false)
-        XCTAssertEqual(side, .west)
-        side.increment(next: false)
-        XCTAssertEqual(side, .south)
-        side.increment(next: false)
-        XCTAssertEqual(side, .east)
-        side.increment(next: false)
-        XCTAssertEqual(side, .north)
-        side.increment(next: false)
-        XCTAssertEqual(side, .west)
-
+        side.increment(next: false); XCTAssertEqual(side, .north)
+        side.increment(next: false); XCTAssertEqual(side, .west)
+        side.increment(next: false); XCTAssertEqual(side, .south)
+        side.increment(next: false); XCTAssertEqual(side, .east)
+        side.increment(next: false); XCTAssertEqual(side, .north)
+        side.increment(next: false); XCTAssertEqual(side, .west)
     }
 
     func test_enum_incremented() {
-        var side = Windrose.north
-        XCTAssertEqual(side, .north)
+        var side = Windrose.north; XCTAssertEqual(side, .north)
 
         XCTAssertEqual(side.incremented(next: true), .east)
         XCTAssertEqual(side.incremented(next: true), .south)
@@ -93,4 +115,3 @@ class EnumExtTests: XCTestCase {
         XCTAssertEqual(side.incremented(next: false), .north)
     }
 }
-

--- a/Tests/RudifaUtilPkgTests/NSAttributedStringExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/NSAttributedStringExtTests.swift
@@ -21,14 +21,18 @@ class NSAttributedStringExtTests: XCTestCase {
                                                                            (currency, .footnote)], separator: " ")
             XCTAssertEqual(pcAttributedString.string, "24.99 € / day")
             XCTAssertEqual(pcAttributedString.length, 13)
-            XCTAssertEqual(pcAttributedString.size(), CGSize(width: 95.9931640625, height: 23.8671875))
+            let size = pcAttributedString.size()
+            XCTAssertEqual(size.width.rounded(), CGFloat(96))
+            XCTAssertEqual(size.height.rounded(), CGFloat(24))
         }
         do {
             let pcAttributedString = NSAttributedString(stringsWithStyle: [(price, .title1),
                                                                            (currency, .title3)], separator: " ")
             XCTAssertEqual(pcAttributedString.string, "24.99 € / day")
             XCTAssertEqual(pcAttributedString.length, 13)
-            XCTAssertEqual(pcAttributedString.size(), CGSize(width: 137.123046875, height: 33.4140625))
+            let size = pcAttributedString.size()
+            XCTAssertEqual(size.width.rounded(), CGFloat(137))
+            XCTAssertEqual(size.height.rounded(), CGFloat(33))
         }
     }
 }


### PR DESCRIPTION
`extension CaseIterable where Self: Equatable: `
- add `func next(next:) `
- deprecate `func increment(next:)` and `incremented(next:)`
- update unit tests