### PR TITLE
simplify debug API printClassAndFunc("...")

### DIFF
--- a/Sources/RudifaUtilPkg/DebugExt.swift
+++ b/Sources/RudifaUtilPkg/DebugExt.swift
@@ -58,9 +58,25 @@ extension NSObject {
     /// - Parameters:
     ///  - info: information string; a leading "@" will be replaced by the call date
     ///  - fnc: current function (default value is the caller)
+    @available(*, deprecated, message: "use printClassAndFunc(\"...\" instead")
     public func printClassAndFunc(info inf_: String = "", fnc fnc_: String = #function) {
         #if DEBUG
             print(formatClassAndFunc(info: inf_, fnc: fnc_))
+        #endif
+    }
+
+    /// Print to stdout current class and function names and optional info
+    ///
+    /// - Note: Printing is enabled by DEBUG constant which is normally absent from release builds.
+    ///
+    /// - Requires: to be called from a subclass of NSObject
+    ///
+    /// - Parameters:
+    ///  - _: information string; a leading "@" will be replaced by the call date
+    ///  - fnc: current function (default value is the caller)
+    public func printClassAndFunc(_ info: String = "", fnc fnc_: String = #function) {
+        #if DEBUG
+            print(formatClassAndFunc(info: info, fnc: fnc_))
         #endif
     }
 

--- a/Sources/RudifaUtilPkg/DebugExt.swift
+++ b/Sources/RudifaUtilPkg/DebugExt.swift
@@ -14,9 +14,9 @@ import Foundation
 ///
 /// `print("any info")`
 ///
-/// `printClassAndFunc(info: "any info")  // ---- ViewController.viewDidLoad() any info`
+/// `printClassAndFunc("any info")  // ---- ViewController.viewDidLoad() any info`
 ///
-/// `printClassAndFunc(info: "@any info") // ---- 2019-12-07 18:05:39.117525 ViewController.viewDidLoad() any info`
+/// `printClassAndFunc("@any info") // ---- 2019-12-07 18:05:39.117525 ViewController.viewDidLoad() any info`
 ///
 /// Log to the app's logfile "Log.txt"
 ///

--- a/Tests/RudifaUtilPkgTests/CollectionExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/CollectionExtTests.swift
@@ -95,7 +95,7 @@ class CollectionExtTests: XCTestCase {
         var calendarDataArray = [MockCalendarData(title: "Newbie", hidden: false),
                                  MockCalendarData(title: "Oldie", hidden: true)]
 
-        printClassAndFunc(info: "original calendarDataArray= \(calendarDataArray.map { $0.string })")
+        printClassAndFunc("original calendarDataArray= \(calendarDataArray.map { $0.string })")
 
         let incomingCalendars = [MockCalendar(title: "Newbie"),
                                  MockCalendar(title: "Oldie"),
@@ -107,7 +107,7 @@ class CollectionExtTests: XCTestCase {
 
         let updatedCalendarDataArray = calendarDataArray.updatedPreservingOrder(from: incomingCalendarDataArray)
 
-        printClassAndFunc(info: "updated calendarDataArray= \(calendarDataArray.map { $0.string })")
+        printClassAndFunc("updated calendarDataArray= \(calendarDataArray.map { $0.string })")
         XCTAssertEqual(updatedCalendarDataArray.map { $0.string }, expectedResultStringArray)
 
         calendarDataArray.updatePreservingOrder(from: incomingCalendarDataArray)
@@ -151,7 +151,7 @@ class CollectionExtTests: XCTestCase {
             let updatedCalendarDataArray = calendarDataArray.updatedPreservingOrder(from: incomingCalendarDataArray,
                                                                                     predicate: sameTitle)
 
-            printClassAndFunc(info: "updatedCalendarDataArray= \(updatedCalendarDataArray.map { $0.string })")
+            printClassAndFunc("updatedCalendarDataArray= \(updatedCalendarDataArray.map { $0.string })")
             XCTAssertEqual(updatedCalendarDataArray.map { $0.string }, expectedResultStringArray)
 
             var localCopy = calendarDataArray
@@ -166,7 +166,7 @@ class CollectionExtTests: XCTestCase {
             let updatedCalendarDataArray = calendarDataArray.updatedPreservingOrder(from: incomingCalendarDataArray,
                                                                                     predicate: { (elt1, elt2) -> Bool in elt1.title == elt2.title })
 
-            printClassAndFunc(info: "updatedCalendarDataArray= \(updatedCalendarDataArray.map { $0.string })")
+            printClassAndFunc("updatedCalendarDataArray= \(updatedCalendarDataArray.map { $0.string })")
             XCTAssertEqual(updatedCalendarDataArray.map { $0.string }, expectedResultStringArray)
 
             var localCopy = calendarDataArray
@@ -181,7 +181,7 @@ class CollectionExtTests: XCTestCase {
             let updatedCalendarDataArray = calendarDataArray.updatedPreservingOrder(from: incomingCalendarDataArray,
                                                                                     predicate: MockCalendarData.sameTitle)
 
-            printClassAndFunc(info: "updatedCalendarDataArray= \(updatedCalendarDataArray.map { $0.string })")
+            printClassAndFunc("updatedCalendarDataArray= \(updatedCalendarDataArray.map { $0.string })")
             XCTAssertEqual(updatedCalendarDataArray.map { $0.string }, expectedResultStringArray)
 
             var localCopy = calendarDataArray

--- a/Tests/RudifaUtilPkgTests/DateIntervalExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/DateIntervalExtTests.swift
@@ -100,7 +100,7 @@ class DateIntervalExtTests: XCTestCase {
         XCTAssertEqual(testDateUTC.HHmmssSSS, "14:42:05.287")
 
         // print using the current time zone
-        printClassAndFunc(info: "testDate= \(testDate.ddMMyyyy_HHmmss), testDateUTC= \(testDateUTC.ddMMyyyy_HHmmss)")
+        printClassAndFunc("testDate= \(testDate.ddMMyyyy_HHmmss), testDateUTC= \(testDateUTC.ddMMyyyy_HHmmss)")
         // XCTAssertEqual(
 
         // test the failable initializer
@@ -170,41 +170,41 @@ class DateIntervalTests: XCTestCase {
 
         let startInThreeQuartersOfHour = DateInterval(start: thisHour.start + oneHour * 0.75, duration: oneHour / 2)
 
-        printClassAndFunc(info: "today \(format(interval: today))")
-        printClassAndFunc(info: "thisHour \(format(interval: thisHour))")
-        printClassAndFunc(info: "theseThreeHours \(format(interval: theseThreeHours))")
-        printClassAndFunc(info: "nextHour \(format(interval: nextHour))")
-        printClassAndFunc(info: "tomorrow \(format(interval: tomorrow))")
-        printClassAndFunc(info: "startInThreeQuartersOfHour \(format(interval: startInThreeQuartersOfHour))")
+        printClassAndFunc("today \(format(interval: today))")
+        printClassAndFunc("thisHour \(format(interval: thisHour))")
+        printClassAndFunc("theseThreeHours \(format(interval: theseThreeHours))")
+        printClassAndFunc("nextHour \(format(interval: nextHour))")
+        printClassAndFunc("tomorrow \(format(interval: tomorrow))")
+        printClassAndFunc("startInThreeQuartersOfHour \(format(interval: startInThreeQuartersOfHour))")
 
         let intersection1 = thisHour.intersection(with: thisHour)!
         dateIntervalFormatter.string(from: intersection1)
-        printClassAndFunc(info: "thisHour.intersection(with: thisHour) \(format(interval: intersection1))]")
-        printClassAndFunc(info: "thisHour.intersects(thisHour) \(thisHour.intersects(thisHour))")
+        printClassAndFunc("thisHour.intersection(with: thisHour) \(format(interval: intersection1))]")
+        printClassAndFunc("thisHour.intersects(thisHour) \(thisHour.intersects(thisHour))")
 
         let intersection2 = thisHour.intersection(with: nextHour)!
         dateIntervalFormatter.string(from: intersection2)
-        printClassAndFunc(info: "thisHour.intersection(nextHour) \(dateIntervalFormatter.string(from: intersection2)!) [\(intersection2.duration)]")
-        printClassAndFunc(info: "thisHour.intersects(nextHour) \(thisHour.intersects(nextHour))")
+        printClassAndFunc("thisHour.intersection(nextHour) \(dateIntervalFormatter.string(from: intersection2)!) [\(intersection2.duration)]")
+        printClassAndFunc("thisHour.intersects(nextHour) \(thisHour.intersects(nextHour))")
 
         let intersection3 = thisHour.intersection(with: startInThreeQuartersOfHour)!
         dateIntervalFormatter.string(from: intersection3)
-        printClassAndFunc(info: "thisHour.intersection(with: startInThreeQuartersOfHour) \(format(interval: intersection3))]")
-        printClassAndFunc(info: "thisHour.intersects(startInThreeQuartersOfHour) \(thisHour.intersects(startInThreeQuartersOfHour))")
+        printClassAndFunc("thisHour.intersection(with: startInThreeQuartersOfHour) \(format(interval: intersection3))]")
+        printClassAndFunc("thisHour.intersects(startInThreeQuartersOfHour) \(thisHour.intersects(startInThreeQuartersOfHour))")
 
         let intersection4 = thisHour.intersection(with: today)!
         dateIntervalFormatter.string(from: intersection4)
-        printClassAndFunc(info: "thisHour.intersection(with: today) \(format(interval: intersection4))]")
-        printClassAndFunc(info: "thisHour.intersects(today) \(thisHour.intersects(today))")
+        printClassAndFunc("thisHour.intersection(with: today) \(format(interval: intersection4))]")
+        printClassAndFunc("thisHour.intersects(today) \(thisHour.intersects(today))")
 
         if let intersection5 = thisHour.intersection(with: tomorrow) {
-            printClassAndFunc(info: "thisHour.intersection(with: tomorrow) \(format(interval: intersection5))]")
+            printClassAndFunc("thisHour.intersection(with: tomorrow) \(format(interval: intersection5))]")
         } else {
-            printClassAndFunc(info: "thisHour.intersection(tomorrow) == nil")
+            printClassAndFunc("thisHour.intersection(tomorrow) == nil")
         }
-        printClassAndFunc(info: "thisHour.intersects(tomorrow) \(thisHour.intersects(tomorrow))")
+        printClassAndFunc("thisHour.intersects(tomorrow) \(thisHour.intersects(tomorrow))")
 
         let intersection6 = thisHour.intersection(with: theseThreeHours)!
-        printClassAndFunc(info: "thisHour.intersection(with: theseThreeHours) \(format(interval: intersection6))]")
+        printClassAndFunc("thisHour.intersection(with: theseThreeHours) \(format(interval: intersection6))]")
     }
 }

--- a/Tests/RudifaUtilPkgTests/DebugExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/DebugExtTests.swift
@@ -9,10 +9,15 @@
 import XCTest
 
 class DebugExtTests: XCTestCase {
+    @available(*, deprecated) // silence warnings
     func test_printClassAndFunc() {
         printClassAndFunc(info: "more info")
         printClassAndFunc(info: "@ even more info at this time")
         printClassAndFunc(info: "@ even more info a tad later")
+
+        printClassAndFunc("more info")
+        printClassAndFunc("@ even more info at this time")
+        printClassAndFunc("@ even more info a tad later")
 
         XCTAssertEqual(formatClassAndFunc(info: "more info"),
                        "---- DebugExtTests.test_printClassAndFunc() more info")


### PR DESCRIPTION
simplify debug API: call `printClassAndFunc("simply like so")`, instead of `printClassAndFunc(info: "the old way requires the arg label")`, now deprecated