### PR TITLE
Fix DebugExt

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/RudifaUtilPkg.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/RudifaUtilPkg.xcscheme
@@ -41,6 +41,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/Sources/RudifaUtilPkg/DebugExt.swift
+++ b/Sources/RudifaUtilPkg/DebugExt.swift
@@ -80,6 +80,19 @@ extension NSObject {
         #endif
     }
 
+    /// Print to stdout current class and function names and optional info
+    ///
+    /// - Note: This third form is only needed to make the call printClassAndFunc() unambigous
+    ///         when both above forms are present in the code.
+    ///
+    /// - TODO: remove when the above deprecated form is removed
+    ///
+    public func printClassAndFunc(_fnc fnc_: String = #function) {
+        #if DEBUG
+            print(formatClassAndFunc(info: "", fnc: fnc_))
+        #endif
+    }
+
     /// Print to log file current class and function names and optional info
     ///
     /// - Requires: to be called from a subclass of NSObject

--- a/Tests/RudifaUtilPkgTests/DebugExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/DebugExtTests.swift
@@ -15,6 +15,8 @@ class DebugExtTests: XCTestCase {
         printClassAndFunc(info: "@ even more info at this time")
         printClassAndFunc(info: "@ even more info a tad later")
 
+        printClassAndFunc()
+        printClassAndFunc("")
         printClassAndFunc("more info")
         printClassAndFunc("@ even more info at this time")
         printClassAndFunc("@ even more info a tad later")


### PR DESCRIPTION
`DebugExt`: add `printClassAndFunc(_fnc fnc_: String = #function)` to remove the compile-time ambiguity in the call `printClassAndFunc()`
`DebugExtTests`: add test cases