### PR TITLE
Date formatted: fix the month names case for slavonic languages

### DIFF
--- a/Sources/RudifaUtilPkg/DateExt.swift
+++ b/Sources/RudifaUtilPkg/DateExt.swift
@@ -12,21 +12,50 @@ import Foundation
 
 public extension Date {
     /// Formats the self per format string, using TimeZone.current
-    ///
     /// - Parameter fmt: a valid DateFormatter format string
     /// - Returns: date+time string
-    private func formatted(fmt: String) -> String {
+
+    /// Format the self per format string, using TimeZone.current
+    /// - Parameters:
+    ///   - fmt: a valid DateFormatter format string
+    ///   - locale: a valid locale identifier (defaults to current locale)
+    /// - Returns: date+time string
+    func formatted(fmt: String, locale: Locale? = nil) -> String {
         let formatter = DateFormatter()
         formatter.timeZone = TimeZone.current // the default is UTC
+        if let locale = locale {
+            formatter.locale = locale // the default is system locale
+        }
         formatter.dateFormat = fmt
         return formatter.string(from: self)
     }
 
-    // computed property returns local date string
+    // MARK: computed properties, return local date strings
 
     /// Returns the local date string like "May 2019"
+    /// Deprecated,
+    /// because in slavonic languages it uses the month name in the genitive case
+    /// e.g. hr: "veljače 2022", pl: "lutego 2022", ru: "февраля 2022"
+    /// however, in this situation the nominative case would be appropriate
+    @available(*, deprecated, message: "use LLLL_yyyy instead")
     var MMMM_yyyy: String {
         return formatted(fmt: "MMMM yyyy")
+    }
+
+    /// Returns the local date string like "February 2022"
+    /// In slavonic languages, uses the month name in the nominative case
+    /// as appropriate in this situation
+    /// e.g. hr: "veljača 2022", pl: "luty 2022", ru: "февраль 2022"
+    var LLLL_yyyy: String {
+        return formatted(fmt: "LLLL yyyy")
+    }
+
+    /// Returns the local date string like "10 February 2022"
+    /// In slavonic languages, uses the month name in the genitive case
+    /// e.g. hr: "10 veljače 2022", pl: "10 lutego 2022", ru: "10 февраля 2022"
+    /// as appropriate in this situation
+    var dd_MMMM_yyyy: String {
+        return formatted(fmt: "dd MMMM yyyy")
     }
 
     /// Returns the local date string like "18.08.2019"
@@ -54,7 +83,7 @@ public extension Date {
         return formatted(fmt: "HH:mm:ss.SSS")
     }
 
-    /// Return a dateTimeString with microsecond resolution, like "2020-10-25 15:42:05.286747"
+    /// Returns a dateTimeString with microsecond resolution, like "2020-10-25 15:42:05.286747"
     var ddMMyyyy_HHmmss_𝜇s: String {
         let cal = Calendar.current
         let comps = cal.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond],

--- a/Sources/RudifaUtilPkg/NSAttributedStringExt.swift
+++ b/Sources/RudifaUtilPkg/NSAttributedStringExt.swift
@@ -8,30 +8,14 @@
 
 import UIKit
 
-extension NSAttributedString {
-    /// Initialize from a string using the fgColor
-    /// - Parameters:
-    ///   - string: input string
-    ///   - color: foreground color
-    public convenience init(string: String, fgColor: UIColor) {
-        let attributes = [NSAttributedString.Key.foregroundColor: fgColor]
-        self.init(string: string, attributes: attributes)
-    }
-
-    /// Initialize from a string using the textStyle
-    /// - Parameters:
-    ///   - string: input string
-    ///   - textStyle: input font text style
-    public convenience init(string: String, textStyle: UIFont.TextStyle) {
-        let attributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: textStyle)]
-        self.init(string: string, attributes: attributes)
-    }
+public extension NSAttributedString {
+    // MARK: API initializers from array of tuples (string, attr, ...)
 
     /// Initialize from an array of strings with color, joining with the separator
     /// - Parameters:
     ///   - stringsWithStyle: array of tuples (string, color)
     ///   - separator: string
-    public convenience init(stringsWithColor: [(String, UIColor)], separator: String = " ") {
+    convenience init(stringsWithColor: [(String, UIColor)], separator: String = " ") {
         let nsaStrings = stringsWithColor.map { NSAttributedString(string: $0.0, fgColor: $0.1) }
         self.init(from: nsaStrings, separator: separator)
     }
@@ -40,15 +24,61 @@ extension NSAttributedString {
     /// - Parameters:
     ///   - stringsWithStyle: array of tuples (string, style)
     ///   - separator: string
-    public convenience init(stringsWithStyle: [(String, UIFont.TextStyle)], separator: String) {
+    convenience init(stringsWithStyle: [(String, UIFont.TextStyle)], separator: String) {
         let nsaStrings = stringsWithStyle.map { NSAttributedString(string: $0.0, textStyle: $0.1) }
         self.init(from: nsaStrings, separator: separator)
     }
+
+    /// Initialize from an array of strings with styles and weights, joining with the separator
+    /// - Parameters:
+    ///   - stringsWithStyle: array of tuples (string, style)
+    ///   - separator: string
+    ///   - weight: font weight, e.g. .thin
+    convenience init(stringsWithStyleAndWeight: [(String, UIFont.TextStyle, weight: UIFont.Weight)], separator: String) {
+        let nsaStrings = stringsWithStyleAndWeight.map { NSAttributedString(string: $0.0, textStyle: $0.1, weight: $0.2) }
+        self.init(from: nsaStrings, separator: separator)
+    }
+
+    // MARK: INTERNAL simple initializers from string and specific attributes
+
+    /// Initialize from a string using the fgColor
+    /// - Parameters:
+    ///   - string: input string
+    ///   - color: foreground color
+    convenience init(string: String, fgColor: UIColor) {
+        let attributes = [NSAttributedString.Key.foregroundColor: fgColor]
+        self.init(string: string, attributes: attributes)
+    }
+
+    /// Initialize from a string using the textStyle
+    /// - Parameters:
+    ///   - string: input string
+    ///   - textStyle: input font text style
+    convenience init(string: String, textStyle: UIFont.TextStyle) {
+        let attributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: textStyle)]
+        self.init(string: string, attributes: attributes)
+    }
+
+    /// Initialize from a string using the textStyle and weight
+    /// - Parameters:
+    ///   - string: input string
+    ///   - textStyle: input font text style
+    ///   - weight: font weight, e.g. .thin
+    convenience init(string: String, textStyle: UIFont.TextStyle, weight: UIFont.Weight) {
+        let font = UIFont.preferredFont(forTextStyle: textStyle)
+        let size = font.pointSize
+        let font2 = UIFont.systemFont(ofSize: size, weight: weight)
+        let attributes = [NSAttributedString.Key.font: font2]
+        self.init(string: string, attributes: attributes)
+    }
+
+    // MARK: INTERNAL initializer with arrays of NSAttributedString
+
     /// Initialize from an array of NSAttributedString, joining with the separator
     /// - Parameters:
     ///   - nsaStrings: array of attributes strings
     ///   - separator: input separator
-    public convenience init(from nsaStrings: [NSAttributedString], separator: String) {
+    convenience init(from nsaStrings: [NSAttributedString], separator: String) {
         let nsaSeparator = NSAttributedString(string: separator)
         let nsmasJoined = NSMutableAttributedString()
         for (index, maString) in nsaStrings.enumerated() {

--- a/Tests/RudifaUtilPkgTests/DateExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/DateExtTests.swift
@@ -56,6 +56,7 @@ class DateExtTests: XCTestCase {
         XCTAssertEqual(weekdaySymbols_M0, ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"])
     }
 
+    @available(*, deprecated) // silence warnings re MMMM_yyyy
     func test_ExtendedDateFormats() {
         let date = Date()
         print("--- date=", date, "ddMMyyy=", date.ddMMyyyy)
@@ -382,5 +383,57 @@ class DateExtTests: XCTestCase {
 
         let twoYearInterval = testDate.twoYearsAround
         XCTAssertEqual(twoYearInterval.durationHours, (365 + 366) * 24)
+    }
+
+    @available(*, deprecated) // silence warnings re MMMM_yyyy
+    func test_formatted_with_locale() {
+        // set an arbitrary date
+        let testDate = Date(timeIntervalSince1970: -1_006_344_000)
+        let secondsFromUTC = TimeZone.current.secondsFromGMT(for: testDate)
+        // get the corresponding date-time in UTC
+        // so that the following tests become independent of the current time zone where tests are executed
+        let testDateUTC = testDate.addingTimeInterval(-TimeInterval(secondsFromUTC))
+
+        // MARK: test formats involving month names
+
+        do {
+            // <month> <year>
+
+            XCTAssertEqual("February 1938", testDateUTC.MMMM_yyyy)
+
+            // in slavonic languages, "MMMM" produces the genitive form of the month names
+            // which is NOT SUITABLE for the <month> <year> forms
+            XCTAssertEqual("veljače 1938", testDateUTC.formatted(fmt: "MMMM yyyy", locale: Locale(identifier: "hr_HR")))
+            XCTAssertEqual("lutego 1938", testDateUTC.formatted(fmt: "MMMM yyyy", locale: Locale(identifier: "pl_PL")))
+            XCTAssertEqual("февраля 1938", testDateUTC.formatted(fmt: "MMMM yyyy", locale: Locale(identifier: "ru_RU")))
+            XCTAssertEqual("February 1938", testDateUTC.formatted(fmt: "MMMM yyyy", locale: Locale(identifier: "en_US")))
+            XCTAssertEqual("février 1938", testDateUTC.formatted(fmt: "MMMM yyyy", locale: Locale(identifier: "fr_CH")))
+        }
+        do {
+            // <day> <month> <year>
+
+            XCTAssertEqual("10 February 1938", testDateUTC.dd_MMMM_yyyy)
+
+            // in slavonic languages, "MMMM" produces the genitive form of the month names
+            // the genitive form is SUITABLE for full dates <day> <month> <year>
+            XCTAssertEqual("10 veljače 1938", testDateUTC.formatted(fmt: "dd MMMM yyyy", locale: Locale(identifier: "hr_HR")))
+            XCTAssertEqual("10 lutego 1938", testDateUTC.formatted(fmt: "dd MMMM yyyy", locale: Locale(identifier: "pl_PL")))
+            XCTAssertEqual("10 февраля 1938", testDateUTC.formatted(fmt: "dd MMMM yyyy", locale: Locale(identifier: "ru_RU")))
+            XCTAssertEqual("10 February 1938", testDateUTC.formatted(fmt: "dd MMMM yyyy", locale: Locale(identifier: "en_US")))
+            XCTAssertEqual("10 février 1938", testDateUTC.formatted(fmt: "dd MMMM yyyy", locale: Locale(identifier: "fr_CH")))
+        }
+        do {
+            // <month> <year>
+
+            XCTAssertEqual("February 1938", testDateUTC.LLLL_yyyy)
+
+            // the nominative form of the month names is obtained with "LLLL"
+            // this is suitable for the form <month> <year>
+            XCTAssertEqual("veljača 1938", testDateUTC.formatted(fmt: "LLLL yyyy", locale: Locale(identifier: "hr_HR")))
+            XCTAssertEqual("luty 1938", testDateUTC.formatted(fmt: "LLLL yyyy", locale: Locale(identifier: "pl_PL")))
+            XCTAssertEqual("февраль 1938", testDateUTC.formatted(fmt: "LLLL yyyy", locale: Locale(identifier: "ru_RU")))
+            XCTAssertEqual("February 1938", testDateUTC.formatted(fmt: "LLLL yyyy", locale: Locale(identifier: "en_US")))
+            XCTAssertEqual("février 1938", testDateUTC.formatted(fmt: "LLLL yyyy", locale: Locale(identifier: "fr_CH")))
+        }
     }
 }


### PR DESCRIPTION
`extension Date`: 
- add the second argument to `func formatted(fmt: String, locale: Locale? = nil)`
- add computed vars `LLLL_yyyy`, `dd_MMMM_yyyy`; 
- deprecate `var MMMM_yyyy`