### PR TITLE
Fix ext encodable and string

### DIFF
--- a/Sources/RudifaUtilPkg/CodableExt.swift
+++ b/Sources/RudifaUtilPkg/CodableExt.swift
@@ -49,7 +49,7 @@ import Foundation
         // handle encode error
     }
  */
-extension Encodable {
+public extension Encodable {
     /// Encode self into Data
     /// THROWING VERSION REMOVED
     /// - Parameter encoder: defaults to JSONEncoder
@@ -62,14 +62,35 @@ extension Encodable {
     /// Encode self into Data?
     /// - Parameter encoder: defaults to JSONEncoder
     /// - Returns: Data?
-    public func encode(_ encoder: JSONEncoder = JSONEncoder()) -> Data? {
+    func encode(_ encoder: JSONEncoder = JSONEncoder()) -> Data? {
         return try? encoder.encode(self)
     }
 
-    /// Encode self into String?
+    /// Encode self into a String?
     /// - Parameter encoder: defaults to JSONEncoder
     /// - Returns: String?
-    public func encode(_ encoder: JSONEncoder = JSONEncoder()) -> String? {
+    func encode(_ encoder: JSONEncoder = JSONEncoder()) -> String? {
+        if let data: Data = encode(encoder) {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
+
+    /// Encode self into a json String?
+    /// - Returns: String?
+    var json: String? {
+        let encoder = JSONEncoder()
+        if let data: Data = encode(encoder) {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
+
+    /// Encode self into a prettyprinted json String?
+    /// - Returns: String?
+    var jsonpp: String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
         if let data: Data = encode(encoder) {
             return String(data: data, encoding: .utf8)
         }
@@ -80,7 +101,7 @@ extension Encodable {
 /**
  Usage examples: see `extension Encodable`
  */
-extension Decodable {
+public extension Decodable {
     /// Decode Data into Self
     /// THROWING VERSION REMOVED
     /// - Parameters:
@@ -97,7 +118,7 @@ extension Decodable {
     ///   - decoder: defaults to JSONDecoder
     ///   - data: previously encoded Data
     /// - Returns: Self?
-    public static func decode(with decoder: JSONDecoder = JSONDecoder(), from data: Data) -> Self? {
+    static func decode(with decoder: JSONDecoder = JSONDecoder(), from data: Data) -> Self? {
         return try? decoder.decode(Self.self, from: data)
     }
 
@@ -106,7 +127,7 @@ extension Decodable {
     ///   - decoder: defaults to JSONDecoder
     ///   - string: previously encoded String
     /// - Returns: Self?
-    public static func decode(with decoder: JSONDecoder = JSONDecoder(), from string: String) -> Self? {
+    static func decode(with decoder: JSONDecoder = JSONDecoder(), from string: String) -> Self? {
         if let data = string.data(using: .utf8) {
             return try? decoder.decode(Self.self, from: data)
         }

--- a/Sources/RudifaUtilPkg/RegexExt.swift
+++ b/Sources/RudifaUtilPkg/RegexExt.swift
@@ -101,7 +101,7 @@ public extension String {
     /// - Parameter regex: String pattern
     /// - Returns: [String]
     ///  Note: deprecated because it does not handle capture groups
-    @available(*, deprecated, message: "use findAllMatches(with:) instead")
+    @available(*, deprecated, message: "use allMatches(with:) instead")
     func matches(for regex: String) -> [String] {
         do {
             let regex = try NSRegularExpression(pattern: regex)

--- a/Tests/RudifaUtilPkgTests/CodableExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/CodableExtTests.swift
@@ -11,6 +11,7 @@ import XCTest
 struct Language: Codable, Equatable {
     var name: String
     var version: String
+    var tiobeIndex: Int?
 }
 
 class CodableExtTests: XCTestCase {
@@ -98,9 +99,40 @@ class CodableExtTests: XCTestCase {
             } else {
                 // handle decode error
                 XCTFail("let lang = Language.decode(from: string)")
-           }
+            }
         } else {
             // handle encode error
+            XCTFail("let string: String = language.encode()")
+        }
+    }
+
+    func test_encode_json_jsonpp() {
+        // create an instance
+        let language = Language(name: "Swift", version: "5.7", tiobeIndex: 18)
+
+        // encode to String?
+        if let string: String = language.encode() {
+            XCTAssertEqual(string, #"{"name":"Swift","version":"5.7","tiobeIndex":18}"#)
+        } else {
+            XCTFail("let string: String = language.encode()")
+        }
+
+        // encode to String?
+        if let string: String = language.json {
+            XCTAssertEqual(string, #"{"name":"Swift","version":"5.7","tiobeIndex":18}"#)
+        } else {
+            XCTFail("let string: String = language.encode()")
+        }
+        // encode to String?
+        if let string: String = language.jsonpp {
+            XCTAssertEqual(string, #"""
+            {
+              "name" : "Swift",
+              "version" : "5.7",
+              "tiobeIndex" : 18
+            }
+            """#)
+        } else {
             XCTFail("let string: String = language.encode()")
         }
     }


### PR DESCRIPTION
`extension Encodable`: add 
- `var json: String? `
- `var jsonpp: String? `

`extension  String`:  fix the deprecation message to read
- `@available(*, deprecated, message: "use allMatches(with:) instead")`