### PR TITLE
revise logClassAndFunc

### DIFF
--- a/Sources/RudifaUtilPkg/DebugExt.swift
+++ b/Sources/RudifaUtilPkg/DebugExt.swift
@@ -49,6 +49,8 @@ import Foundation
 /// - Open the app's directory as above, right-click on the file and click `Delete`
 
 public extension NSObject {
+    // MARK: print to console (DEBUG only)
+
     /// Print to stdout current class and function names and optional info
     ///
     /// - Note: Printing is enabled by DEBUG constant which is normally absent from release builds.
@@ -93,6 +95,8 @@ public extension NSObject {
         #endif
     }
 
+    // MARK: log to file log.txt
+
     /// Print to log file current class and function names and optional info
     ///
     /// - Requires: to be called from a subclass of NSObject
@@ -100,16 +104,43 @@ public extension NSObject {
     /// - Parameters:
     ///  - info: information string; a leading "@" will be replaced by the call date
     ///  - fnc: current function (default value is the caller)
+    @available(*, deprecated, message: "use logClassAndFunc(\"...\" instead")
     func logClassAndFunc(info inf_: String = "", fnc fnc_: String = #function) {
         Logger.shared.print(formatClassAndFunc(info: inf_, fnc: fnc_))
     }
+
+    /// Print to log file current class and function names and optional info
+    ///
+    /// - Note: Printing is enabled by DEBUG constant which is normally absent from release builds.
+    ///
+    /// - Requires: to be called from a subclass of NSObject
+    ///
+    /// - Parameters:
+    ///  - _: information string; a leading "@" will be replaced by the call date
+    ///  - fnc: current function (default value is the caller)
+    func logClassAndFunc(_ info: String = "", fnc fnc_: String = #function) {
+        Logger.shared.print(formatClassAndFunc(info: info, fnc: fnc_))
+    }
+
+    /// Print to log file current class and function names and optional info
+    ///
+    /// - Note: This third form is only needed to make the call logClassAndFunc() unambigous
+    ///         when both above forms are present in the code.
+    ///
+    /// - TODO: remove when the above deprecated form is removed
+    ///
+    func logClassAndFunc(_fnc fnc_: String = #function) {
+        Logger.shared.print(formatClassAndFunc(info: "", fnc: fnc_))
+    }
+
+    // MARK: supporting functions
 
     /// Return a string containing current class and function names and optional info
     /// - Requires: to be called from a subclass of NSObject
     /// - Parameters:
     ///  - info: information string; a leading "@" will be replaced by the call date
     ///  - fnc: current function (default value is the caller)
-    func formatClassAndFunc(info inf_: String = "", fnc fnc_: String = #function) -> String {
+    internal func formatClassAndFunc(info inf_: String = "", fnc fnc_: String = #function) -> String {
         var dateTime = ""
         var info = inf_
         if inf_.first == "@" {

--- a/Tests/RudifaUtilPkgTests/DebugExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/DebugExtTests.swift
@@ -11,23 +11,22 @@ import XCTest
 class DebugExtTests: XCTestCase {
     @available(*, deprecated) // silence warnings
     func test_printClassAndFunc() {
+        // deprecated style
         printClassAndFunc(info: "more info")
         printClassAndFunc(info: "@ even more info at this time")
         printClassAndFunc(info: "@ even more info a tad later")
 
+        // current style
         printClassAndFunc()
         printClassAndFunc("")
         printClassAndFunc("more info")
         printClassAndFunc("@ even more info at this time")
         printClassAndFunc("@ even more info a tad later")
 
-        XCTAssertEqual(formatClassAndFunc(info: "more info"),
-                       "---- DebugExtTests.test_printClassAndFunc() more info")
-
-        XCTAssertMatchesRegex(formatClassAndFunc(info: "@"),
-                              #"^---- \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} DebugExtTests.test_printClassAndFunc\(\) $"#)
-
-        XCTAssertMatchesRegex(formatClassAndFunc(info: "@ even more info at this time"),
-                              #"^---- \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} DebugExtTests.test_printClassAndFunc\(\)  even more info at this time$"#)
+        logClassAndFunc()
+        logClassAndFunc("")
+        logClassAndFunc("more info")
+        logClassAndFunc("@ even more info at this time")
+        logClassAndFunc("@ even more info a tad later")
     }
 }


### PR DESCRIPTION
- deprecate the form  `logClassAndFunc(info: "more info")`
- suggest the form `logClassAndFunc("more info")` 

