### PR TITLE
FileBackedDictionary: prevent errors in saving/restoring 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,50 @@
 
 [RudifaUtilPkg](https://rudifa.github.io/RudifaUtilPkg/) contains swift extensions and utility methods.
 
+
+## Highlights
+
+### FileBackedDictionary
+
+
+ `struct FileBackedDictionary`  encapsulates a `[String:T]` dictionary whose values are automatically persisted, each in its own file.
+
+ `FileBackedDictionary` exposes methods and properties similar to those of the Swift Dictionary.
+
+ At its initialization (typically at the application start), an instance of `FileBackedDictionary` recovers the keys and values from the file storage (if any have been stored in previous application runs).
+
+### Usage examples ###
+
+ Create a `FileBackedDictionary` instance, with a directory named `MyResources` and `struct Resource` as type of the values to store.
+
+```
+        let directoryName = "MyResources"
+        var fbDict = FileBackedDictionary<Resource>(directoryName: directoryName)
+```
+
+ Add `Resource` instances
+
+```
+        fbDict["apples"] = Resource(name: "apples", value: 1, quantity: 1)
+        fbDict["oranges"] = Resource(name: "oranges", value: 2, quantity: 2)
+        fbDict["mangos"] = Resource(name: "mangos", value: 3, quantity: 3)
+```
+
+ Look up the resource info
+
+```
+        let count = fbDict.count			// 3
+        let keys = fbDict.keys			// ["apples", "oranges", "mangos"])
+        let values = fbDict.values 		// [...]
+        let myOranges = fbDict["oranges"]
+```
+
+ Remove resources
+
+```
+        fbDict["oranges"] = nil
+        fbDict.removeAll()
+```
+
+
+

--- a/Sources/RudifaUtilPkg/CodableExt.swift
+++ b/Sources/RudifaUtilPkg/CodableExt.swift
@@ -71,7 +71,7 @@ public extension Encodable {
     /// - Parameter encoder: defaults to JSONEncoder
     /// - Returns: Data?
     func encode(_ encoder: JSONEncoder = JSONEncoder()) -> Data? {
-        return try? encoder.encode(self)
+        try? encoder.encode(self)
     }
 
     /// Encode self into a String?
@@ -86,16 +86,30 @@ public extension Encodable {
 
     /// Encode self into a json String?
     /// - Returns: String?
+    var encode: String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        if let data = try? encoder.encode(self) {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
+
+    /// Encode self into a json String?
+    /// - Returns: String?
     var json: String? {
-        return encode()
+        encode
     }
 
     /// Encode self into a prettyprinted json String?
     /// - Returns: String?
     var jsonpp: String? {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        return encode(encoder)
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        if let data = try? encoder.encode(self) {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
     }
 }
 
@@ -120,7 +134,7 @@ public extension Decodable {
     ///   - data: previously encoded Data
     /// - Returns: Self?
     static func decode(with decoder: JSONDecoder = JSONDecoder(), from data: Data) -> Self? {
-        return try? decoder.decode(Self.self, from: data)
+        try? decoder.decode(Self.self, from: data)
     }
 
     /// Decode String into Self?

--- a/Tests/RudifaUtilPkgTests/CodableExtTests.swift
+++ b/Tests/RudifaUtilPkgTests/CodableExtTests.swift
@@ -46,7 +46,7 @@ class CodableExtTests: XCTestCase {
         let language = Language(name: "Swift", version: "5.3")
 
         // encode to String?
-        guard let string: String = language.encode() else {
+        guard let string: String = language.encode else {
             XCTFail("language.encode()")
             return
         }
@@ -88,7 +88,7 @@ class CodableExtTests: XCTestCase {
         }
 
         // encode to String?
-        if let string: String = language.encode() {
+        if let string: String = language.encode {
             // use string here
             XCTAssertEqual(string, #"{"name":"Swift","version":"5.3"}"#)
 
@@ -111,15 +111,15 @@ class CodableExtTests: XCTestCase {
         let language = Language(name: "Swift", version: "5.7", tiobeIndex: 18)
 
         // encode to String?
-        if let string: String = language.encode() {
-            XCTAssertEqual(string, #"{"name":"Swift","version":"5.7","tiobeIndex":18}"#)
+        if let string: String = language.encode {
+            XCTAssertEqual(string, #"{"name":"Swift","tiobeIndex":18,"version":"5.7"}"#)
         } else {
             XCTFail("let string: String = language.encode()")
         }
 
         // encode to String?
         if let string: String = language.json {
-            XCTAssertEqual(string, #"{"name":"Swift","version":"5.7","tiobeIndex":18}"#)
+            XCTAssertEqual(string, #"{"name":"Swift","tiobeIndex":18,"version":"5.7"}"#)
         } else {
             XCTFail("let string: String = language.encode()")
         }
@@ -128,8 +128,8 @@ class CodableExtTests: XCTestCase {
             XCTAssertEqual(string, #"""
             {
               "name" : "Swift",
-              "version" : "5.7",
-              "tiobeIndex" : 18
+              "tiobeIndex" : 18,
+              "version" : "5.7"
             }
             """#)
         } else {

--- a/Tests/RudifaUtilPkgTests/FileBackedDictionaryTests.swift
+++ b/Tests/RudifaUtilPkgTests/FileBackedDictionaryTests.swift
@@ -83,6 +83,12 @@ class FileBackedDictionaryTests: XCTestCase {
         let directoryName = "test_directory2"
         var fbDict = FileBackedDictionary<Resource>(directoryName: directoryName)
 
+        // remove all (from a previous test run)
+        fbDict.removeAll()
+        XCTAssertEqual(fbDict.count, 0)
+        XCTAssertEqual(fbDict.keys, [])
+        XCTAssertEqual(fbDict.fileNames, [])
+
         // create an array of resources
         let resource1 = Resource(name: "resource_1", value: 1, quantity: 1)
         let resource2 = Resource(name: "resource_2", value: 2, quantity: 2)
@@ -94,13 +100,119 @@ class FileBackedDictionaryTests: XCTestCase {
             fbDict[resource.name] = resource
         }
 
-        XCTAssertEqual(fbDict.count, 3)
-        XCTAssertEqual(fbDict.keys, ["resource_1", "resource_2", "resource_3"])
-        XCTAssertEqual(fbDict.values, [resource1, resource2, resource3])
+        // check the filenames
+        XCTAssertEqual(fbDict.fileNames, ["resource_1", "resource_2", "resource_3"])
 
-        fbDict.removeValue(forKey: "resource_2")
-        XCTAssertEqual(fbDict.count, 2)
-        XCTAssertEqual(fbDict.keys, ["resource_1", "resource_3"])
-        XCTAssertEqual(fbDict.values, [resource1, resource3])
-   }
+        do {
+            // can we add a resource with a filename containig "/"?
+            let resource4 = Resource(name: "resource_4/slash", value: 4, quantity: 4)
+            fbDict[resource4.name] = resource4
+            XCTAssertEqual(fbDict.count, 3)
+            XCTAssertEqual(fbDict.keys, ["resource_1", "resource_2", "resource_3"])
+
+            // check that the resource4 fileName is MISSING
+            // (because the creation of the file silently failed)
+            XCTAssertEqual(fbDict.fileNames, ["resource_1", "resource_2", "resource_3"])
+        }
+
+        do {
+            // can we add a resource with a filename containig a leading "."?
+            let resource5 = Resource(name: ".resource_5leadingperiod", value: 5, quantity: 5)
+            fbDict[resource5.name] = resource5
+            XCTAssertEqual(fbDict.count, 4)
+            XCTAssertEqual(fbDict.keys, [".resource_5leadingperiod", "resource_1", "resource_2", "resource_3"])
+
+            // check that the resource5 fileName is not missing (it is a hidden file but fileNames lists these)
+            // (because the creation of the file silently failed)
+            XCTAssertEqual(fbDict.fileNames, [".resource_5leadingperiod", "resource_1", "resource_2", "resource_3"])
+        }
+    }
+
+    func test_FileBackedDictionary3() {
+        // remove the target file directory, in case it was polluted by previous tests
+        FileBackedDictionary<Resource>.deleteDirectory(named: "test_directory3")
+
+        // create a FileBackedDictionary under test with directory named
+        // "test_directory" using struct Resource as the value type
+        let directoryName = "test_directory3"
+        var fbDict = FileBackedDictionary<Resource>(directoryName: directoryName)
+
+        // remove all (from a previous test run)
+        fbDict.removeAll()
+        XCTAssertEqual(fbDict.count, 0)
+        XCTAssertEqual(fbDict.keys, [])
+        XCTAssertEqual(fbDict.fileNames, [])
+
+        // can we add a resource with a name containig suspect characters?
+
+        // Tests below show that all of 29 suspect characters are allowed in FileManager filenames
+        // EXCEPT "/", which must be disallowed in FileBackedDictionary keys.
+
+        // Create an array of resources where each name contains one of the suspect characters
+        let resourcesWithSuspectNames = [
+            Resource(name: "resource_11/slash", value: 11, quantity: 11),
+            Resource(name: "resource_12:colon", value: 12, quantity: 12),
+            Resource(name: "resource_13\\backslash", value: 13, quantity: 13),
+            Resource(name: "resource_14*asterisk", value: 14, quantity: 14),
+            Resource(name: "resource_15?questionmark", value: 15, quantity: 15),
+            Resource(name: "resource_16<lessthan", value: 16, quantity: 16),
+            Resource(name: "resource_17>greaterthan", value: 17, quantity: 17),
+            Resource(name: "resource_18|pipe", value: 18, quantity: 18),
+            Resource(name: "resource_19\"quote", value: 19, quantity: 19),
+            Resource(name: " resource_20leadingwhitespace", value: 20, quantity: 20),
+            Resource(name: "resource_21trailingwhitespace ", value: 21, quantity: 21),
+            Resource(name: ".resource_22leadingperiod", value: 22, quantity: 22),
+            Resource(name: "resource_23.notleadingperiod", value: 23, quantity: 23),
+
+            // add some more punctuation characters: "@ # $ % & () [] {} = + ; , ~"
+
+            Resource(name: "resource_24@at", value: 24, quantity: 24),
+            Resource(name: "resource_25#hash", value: 25, quantity: 25),
+            Resource(name: "resource_26$dollar", value: 26, quantity: 26),
+            Resource(name: "resource_27%percent", value: 27, quantity: 27),
+            Resource(name: "resource_28&and", value: 28, quantity: 28),
+            Resource(name: "resource_29(leftparen", value: 29, quantity: 29),
+            Resource(name: "resource_30)rightparen", value: 30, quantity: 30),
+            Resource(name: "resource_31[leftbracket", value: 31, quantity: 31),
+            Resource(name: "resource_32]rightbracket", value: 32, quantity: 32),
+            Resource(name: "resource_33{leftbrace", value: 33, quantity: 33),
+            Resource(name: "resource_34}rightbrace", value: 34, quantity: 34),
+            Resource(name: "resource_35=equal", value: 35, quantity: 35),
+            Resource(name: "resource_36+plus", value: 36, quantity: 36),
+            Resource(name: "resource_37;semicolon", value: 37, quantity: 37),
+            Resource(name: "resource_38,comma", value: 38, quantity: 38),
+            Resource(name: "resource_39~tilde", value: 39, quantity: 39),
+        ]
+        // add the resources to the dictionary from array, using the name as key
+        for resource in resourcesWithSuspectNames {
+            fbDict[resource.name] = resource
+        }
+
+        // loop over the resources and print the index and the name
+        for (index, resource) in resourcesWithSuspectNames.enumerated() {
+            printClassAndFunc("index= \(index), resource.name= \"\(resource.name)\"")
+        }
+
+        // compare the numbers
+        XCTAssertEqual(resourcesWithSuspectNames.count, 29)
+        XCTAssertEqual(fbDict.count, 28)
+        XCTAssertEqual(fbDict.fileNames.count, 28)
+
+        // make sets of expected names, of actual fbdict.keys and the fbdict.enumFiles()
+        let resourceNames = Set(resourcesWithSuspectNames.map(\.name))
+        let actualDictKeys = Set(fbDict.keys)
+        let actualFilenames = Set(fbDict.fileNames)
+
+        // find the missing keys and filenames
+        let missingDictKeys = resourceNames.subtracting(actualDictKeys)
+        let missingFilenames = resourceNames.subtracting(actualFilenames)
+
+        // check that the set of missing dictKeys is as expected
+        let expectedMissingDictKeys: Set<String> = ["resource_11/slash"] // missing because a file creation with this name failed
+        XCTAssertEqual(missingDictKeys, expectedMissingDictKeys)
+
+        // check that the set of missing filenames is as expected
+        let expectedMissingFilenames: Set<String> = ["resource_11/slash"]
+        XCTAssertEqual(missingFilenames, expectedMissingFilenames)
+    }
 }


### PR DESCRIPTION
FileBackedDictionary: prevent discrepancies between in-memory dictionary and the backing files

FileBackedDictionary: 
- replace unreliable createFile by write(to: ...) 
- add public static func deleteDirectory(named directoryName: String) 
- use throw / try / catch to propagate and handle errors 
- add public var fileNames: [String], update tests 

extension Encodable: encoding to String? now uses .sortedKeys

run swiftformat --swiftversion 5.9.2
